### PR TITLE
Update CustomPayloadFixer.java

### DIFF
--- a/src/ru/justblender/bungee/CustomPayloadFixer.java
+++ b/src/ru/justblender/bungee/CustomPayloadFixer.java
@@ -11,7 +11,7 @@ import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 import net.md_5.bungee.event.EventHandler;
-import org.apache.commons.io.Charsets;
+import com.google.common.base.Charsets;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,9 +67,6 @@ public class CustomPayloadFixer extends Plugin implements Listener {
 
         try {
             if ("REGISTER".equals(name)) {
-                if (((ProxiedPlayer) connection).isForgeUser() && ignoreForge)
-                    return;
-
                 if (!CHANNELS_REGISTERED.containsKey(connection))
                     CHANNELS_REGISTERED.put(connection, new AtomicInteger());
 


### PR DESCRIPTION
You have an error in your plugin, that's why Forge users can't connect. This should fix the problem with players using Forge. 

What happens is, you are importing Charsets from bukkit instead of bungeecord. When a Forge user tries to connect, it goes through the REGISTER channel, and since Charsets class is not defined in bungeecord, it launches a wrong exception catched as exploit:
java.lang.NoClassDefFoundError: org/apache/commons/io/Charsets

A normal user doesn't fall into this, because they never reach the line where Charsets is.